### PR TITLE
Fix docker healthcheck.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,7 +108,7 @@ WORKDIR /app
 
 USER superset
 
-HEALTHCHECK CMD ["curl", "-f", "http://localhost:8088/health"]
+HEALTHCHECK CMD ["curl", "-f", "http://localhost:$$SUPERSET_PORT/health"]
 
 EXPOSE ${SUPERSET_PORT}
 


### PR DESCRIPTION
### SUMMARY
Fix docker healthcheck.

Default env `SUPERSET_PORT` is 8080 but health check is check for 8088.
It should follow the environment in health check.